### PR TITLE
0.5.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "jest": "^29.2.2",
         "prettier": "^2.7.1",
         "rollup": "^3.2.5",
-        "rollup-plugin-esbuild": "^4.10.2",
+        "rollup-plugin-esbuild": "^5.0.0",
         "rollup-plugin-node-externals": "^5.0.2",
         "rollup-plugin-typescript-paths": "^1.4.0",
         "ts-jest": "^29.0.3",
@@ -4784,9 +4784,9 @@
       }
     },
     "node_modules/rollup-plugin-esbuild": {
-      "version": "4.10.2",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-esbuild/-/rollup-plugin-esbuild-4.10.2.tgz",
-      "integrity": "sha512-OPrBgdN1ZC2zQvq/rm5Zvzpb0Rez7zbbVJ+1b5Az//kLlfhwR1mqOP3wAhkg9sn5nF7p+97p55TORE0RNXzNcw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-esbuild/-/rollup-plugin-esbuild-5.0.0.tgz",
+      "integrity": "sha512-1cRIOHAPh8WQgdQQyyvFdeOdxuiyk+zB5zJ5+YOwrZP4cJ0MT3Fs48pQxrZeyZHcn+klFherytILVfE4aYrneg==",
       "dev": true,
       "dependencies": {
         "@rollup/pluginutils": "^5.0.1",
@@ -8861,9 +8861,9 @@
       }
     },
     "rollup-plugin-esbuild": {
-      "version": "4.10.2",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-esbuild/-/rollup-plugin-esbuild-4.10.2.tgz",
-      "integrity": "sha512-OPrBgdN1ZC2zQvq/rm5Zvzpb0Rez7zbbVJ+1b5Az//kLlfhwR1mqOP3wAhkg9sn5nF7p+97p55TORE0RNXzNcw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-esbuild/-/rollup-plugin-esbuild-5.0.0.tgz",
+      "integrity": "sha512-1cRIOHAPh8WQgdQQyyvFdeOdxuiyk+zB5zJ5+YOwrZP4cJ0MT3Fs48pQxrZeyZHcn+klFherytILVfE4aYrneg==",
       "dev": true,
       "requires": {
         "@rollup/pluginutils": "^5.0.1",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "jest": "^29.2.2",
     "prettier": "^2.7.1",
     "rollup": "^3.2.5",
-    "rollup-plugin-esbuild": "^4.10.2",
+    "rollup-plugin-esbuild": "^5.0.0",
     "rollup-plugin-node-externals": "^5.0.2",
     "rollup-plugin-typescript-paths": "^1.4.0",
     "ts-jest": "^29.0.3",


### PR DESCRIPTION
rollup-plugin-esbuild `4.10.2` was meant to be a major release, so bumping it to `5.0.0`

Close #17 